### PR TITLE
Use haskell-src-exts-simple & fix base upperbound.

### DIFF
--- a/desugar.cabal
+++ b/desugar.cabal
@@ -19,6 +19,6 @@ executable desugar
   main-is:             Main.hs
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.7 && <4.8, haskell-src-exts, syb
+  build-depends:       base >=4.7 && < 4.10, haskell-src-exts-simple, syb
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This allows desugar to be built with GHC 8.0.2.